### PR TITLE
Bugfix: cannot enter price type with an external id of minimum

### DIFF
--- a/ApplicationCore/DataModel/PriceTypeValidator.cs
+++ b/ApplicationCore/DataModel/PriceTypeValidator.cs
@@ -14,6 +14,6 @@ public class PriceTypeValidator : AbstractValidator<PriceType>
 			.MaximumLength(80);
 
 		RuleFor(priceType => priceType.ExternalId)
-			.MaximumLength(4);
+			.MaximumLength(8);
 	}
 }

--- a/ApplicationCore/Database/PriceTypeConfiguration.cs
+++ b/ApplicationCore/Database/PriceTypeConfiguration.cs
@@ -23,6 +23,6 @@ public sealed class PriceTypeConfiguration : BaseEntityConfiguration<PriceType>
             .HasMaxLength(80);
 
         builder.Property(priceType => priceType.ExternalId)
-            .HasMaxLength(4);
+            .HasMaxLength(8);
     }
 }

--- a/ApplicationCore/Database/UnitOfMeasureConfiguration.cs
+++ b/ApplicationCore/Database/UnitOfMeasureConfiguration.cs
@@ -15,6 +15,6 @@ internal class UnitOfMeasureConfiguration : BaseEntityConfiguration<UnitOfMeasur
             .HasMaxLength(80);
 
         builder.Property(uom => uom.ExternalId)
-            .HasMaxLength(4);
+            .HasMaxLength(8);
     }
 }

--- a/ApplicationCore/Migrations/20230322193005_UpdatedExternalIDLength.Designer.cs
+++ b/ApplicationCore/Migrations/20230322193005_UpdatedExternalIDLength.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using ApplicationCore.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace ApplicationCore.Migrations
 {
     [DbContext(typeof(StraboContext))]
-    partial class StraboContextModelSnapshot : ModelSnapshot
+    [Migration("20230322193005_UpdatedExternalIDLength")]
+    partial class UpdatedExternalIDLength
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ApplicationCore/Migrations/20230322193005_UpdatedExternalIDLength.cs
+++ b/ApplicationCore/Migrations/20230322193005_UpdatedExternalIDLength.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ApplicationCore.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpdatedExternalIDLength : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "ExternalId",
+                table: "UnitsOfMeasure",
+                type: "character varying(8)",
+                maxLength: 8,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(4)",
+                oldMaxLength: 4,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ExternalId",
+                table: "PriceTypes",
+                type: "character varying(8)",
+                maxLength: 8,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(4)",
+                oldMaxLength: 4,
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "ExternalId",
+                table: "UnitsOfMeasure",
+                type: "character varying(4)",
+                maxLength: 4,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(8)",
+                oldMaxLength: 8,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ExternalId",
+                table: "PriceTypes",
+                type: "character varying(4)",
+                maxLength: 4,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(8)",
+                oldMaxLength: 8,
+                oldNullable: true);
+        }
+    }
+}

--- a/UI/Pages/PriceTypes.razor
+++ b/UI/Pages/PriceTypes.razor
@@ -50,7 +50,7 @@
 
 	async Task NewClicked()
 	{
-		var dialog = await DialogService.ShowAsync<PriceTypeDialog>("Create rpice type");
+		var dialog = await DialogService.ShowAsync<PriceTypeDialog>("Create price type");
 		var result = await dialog.Result;
 
 		if (result.Data is PriceType createdPriceType)

--- a/UI/Properties/launchSettings.json
+++ b/UI/Properties/launchSettings.json
@@ -8,7 +8,6 @@
   "profiles": {
     "http": {
       "commandName": "Project",
-      "dotnetRunMessages": true,
       "launchBrowser": true,
       "applicationUrl": "http://localhost:5014",
       "environmentVariables": {
@@ -17,7 +16,6 @@
     },
     "https": {
       "commandName": "Project",
-      "dotnetRunMessages": true,
       "launchBrowser": true,
       "applicationUrl": "https://localhost:7005;http://localhost:5014",
       "environmentVariables": {

--- a/UI/UI.csproj
+++ b/UI/UI.csproj
@@ -6,6 +6,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(RunConfiguration)' == 'https' " />
+  <PropertyGroup Condition=" '$(RunConfiguration)' == 'http' " />
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="11.5.1" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.2.2" />


### PR DESCRIPTION
### **Description of Work:**
This pull request correlates to the issue referenced here: 
[https://github.com/StraboPartners/DotNetCodeTest/issues/1](https://github.com/StraboPartners/DotNetCodeTest/issues/1)

The character count for External ID was set to `4` I changed the character count to `8` allowing the field to be populated with the value of `Minimum`. 

## **Test Notes**
- Launch the Application
- Navigate to the Setup > Price Types tab
- Click the "+" Icon to add a new Price Type record
- Enter the "Minimum" value in the "External ID" Field (The character count was bumped up to 8)