### PR TITLE
Bugfix: Prices should not be able to overlap

### DIFF
--- a/ApplicationCore/Services/Prices/PriceDbAccess.cs
+++ b/ApplicationCore/Services/Prices/PriceDbAccess.cs
@@ -23,11 +23,22 @@ public class PriceDbAccess : IPriceDbAccess
 
 	public async Task<Price> CreatePrice(Price price)
 	{
-		await using var context = await _dbContextFactory.CreateDbContextAsync();
-		context.Prices.Add(price);
-		await context.SaveChangesAsync();
-		return price;
-	}
+        await using var context = await _dbContextFactory.CreateDbContextAsync();
+
+        var existingPrice = await context.Prices
+            .Where(p => p.ProductId == price.ProductId)
+            .FirstOrDefaultAsync();
+
+        if (existingPrice != null)
+        {
+            throw new InvalidOperationException($"A price with Id '{price.Id}' already exists for the product with Id '{price.ProductId}'.");
+        }
+
+        context.Prices.Add(price);
+        await context.SaveChangesAsync();
+
+        return price;
+    }
 
 	public async Task<Price> UpdatePrice(Price price)
 	{

--- a/UI/Properties/launchSettings.json
+++ b/UI/Properties/launchSettings.json
@@ -8,7 +8,6 @@
   "profiles": {
     "http": {
       "commandName": "Project",
-      "dotnetRunMessages": true,
       "launchBrowser": true,
       "applicationUrl": "http://localhost:5014",
       "environmentVariables": {
@@ -17,7 +16,6 @@
     },
     "https": {
       "commandName": "Project",
-      "dotnetRunMessages": true,
       "launchBrowser": true,
       "applicationUrl": "https://localhost:7005;http://localhost:5014",
       "environmentVariables": {

--- a/UI/UI.csproj
+++ b/UI/UI.csproj
@@ -6,6 +6,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(RunConfiguration)' == 'https' " />
+  <PropertyGroup Condition=" '$(RunConfiguration)' == 'http' " />
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="11.5.1" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.2.2" />


### PR DESCRIPTION
### **Description of Work**
This Pull Request Correlates to the issue here:
[https://github.com/StraboPartners/DotNetCodeTest/issues/3](https://github.com/StraboPartners/DotNetCodeTest/issues/3)
This was an attempt to prevent users from entering overlapping prices. 

### **Test Notes**
- Launch the application
- Navigate to Prices
- Add a new record with the same product Id in the table
- An error should occur with a red banner at the bottom
- If you use chrome tools to inspect the application and navigate to the Console tab you should see an error with a prompt - that the ID  already exists in the table. And example is listed below:
<img width="1437" alt="Screen Shot 2023-03-23 at 11 18 00 AM" src="https://user-images.githubusercontent.com/15929840/227321435-c5a4d3dc-68a6-4fa2-b409-024daee3c87b.png">

