### PR TITLE
Feature: Price creation product selection should be a dropdown

### DIFF
--- a/ApplicationCore/ApplicationCore.csproj
+++ b/ApplicationCore/ApplicationCore.csproj
@@ -9,6 +9,10 @@
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="11.5.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.3" />
   </ItemGroup>
 

--- a/ApplicationCore/DataModel/PriceTypeValidator.cs
+++ b/ApplicationCore/DataModel/PriceTypeValidator.cs
@@ -14,6 +14,6 @@ public class PriceTypeValidator : AbstractValidator<PriceType>
 			.MaximumLength(80);
 
 		RuleFor(priceType => priceType.ExternalId)
-			.MaximumLength(4);
+			.MaximumLength(20);
 	}
 }

--- a/ApplicationCore/DataModel/UnitOfMeasureValidator.cs
+++ b/ApplicationCore/DataModel/UnitOfMeasureValidator.cs
@@ -1,0 +1,19 @@
+﻿using FluentValidation;
+
+namespace ApplicationCore.DataModel;
+
+public class UnitOfMeasureValidator : AbstractValidator<UnitOfMeasure>
+{
+	public UnitOfMeasureValidator()
+	{
+		RuleFor(unitOfMeasure => unitOfMeasure.Name)
+			.NotEmpty()
+			.MaximumLength(20);
+
+		RuleFor(unitOfMeasure => unitOfMeasure.Description)
+			.MaximumLength(80);
+
+		RuleFor(unitOfMeasure => unitOfMeasure.ExternalId)
+			.MaximumLength(4);
+	}
+}

--- a/ApplicationCore/Database/PriceTypeConfiguration.cs
+++ b/ApplicationCore/Database/PriceTypeConfiguration.cs
@@ -23,6 +23,6 @@ public sealed class PriceTypeConfiguration : BaseEntityConfiguration<PriceType>
             .HasMaxLength(80);
 
         builder.Property(priceType => priceType.ExternalId)
-            .HasMaxLength(4);
+            .HasMaxLength(20);
     }
 }

--- a/ApplicationCore/Migrations/20230327010418_IncreasePriceType.ExternalIdMaxLengthTo20.Designer.cs
+++ b/ApplicationCore/Migrations/20230327010418_IncreasePriceType.ExternalIdMaxLengthTo20.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using ApplicationCore.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace ApplicationCore.Migrations
 {
     [DbContext(typeof(StraboContext))]
-    partial class StraboContextModelSnapshot : ModelSnapshot
+    [Migration("20230327010418_IncreasePriceType.ExternalIdMaxLengthTo20")]
+    partial class IncreasePriceTypeExternalIdMaxLengthTo20
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ApplicationCore/Migrations/20230327010418_IncreasePriceType.ExternalIdMaxLengthTo20.cs
+++ b/ApplicationCore/Migrations/20230327010418_IncreasePriceType.ExternalIdMaxLengthTo20.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ApplicationCore.Migrations
+{
+    /// <inheritdoc />
+    public partial class IncreasePriceTypeExternalIdMaxLengthTo20 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "ExternalId",
+                table: "PriceTypes",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(4)",
+                oldMaxLength: 4,
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "ExternalId",
+                table: "PriceTypes",
+                type: "character varying(4)",
+                maxLength: 4,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(20)",
+                oldMaxLength: 20,
+                oldNullable: true);
+        }
+    }
+}

--- a/ApplicationCore/Services/Prices/IPriceDbAccess.cs
+++ b/ApplicationCore/Services/Prices/IPriceDbAccess.cs
@@ -13,4 +13,9 @@ public interface IPriceDbAccess
 	Task<PriceType> CreatePriceType(PriceType priceType);
 	Task<PriceType> UpdatePriceType(PriceType priceType);
 	Task<int> DeletePriceTypes(HashSet<long> priceTypeIds);
+
+	Task<List<UnitOfMeasure>> GetAllUnitsOfMeasure();
+	Task<UnitOfMeasure> CreateUnitOfMeasure(UnitOfMeasure unitOfMeasure);
+	Task<UnitOfMeasure> UpdateUnitOfMeasure(UnitOfMeasure unitOfMeasure);
+	Task<int> DeleteUnitsOfMeasure(HashSet<long> unitOfMeasureIds);
 }

--- a/ApplicationCore/Services/Prices/IPriceService.cs
+++ b/ApplicationCore/Services/Prices/IPriceService.cs
@@ -1,4 +1,5 @@
 using ApplicationCore.DataModel;
+using System.Threading.Tasks;
 
 namespace ApplicationCore.Services;
 
@@ -13,4 +14,9 @@ public interface IPriceService
 	Task<PriceType> CreatePriceType(PriceType priceType);
 	Task<PriceType> UpdatePriceType(PriceType priceType);
 	Task<int> DeletePriceTypes(HashSet<long> priceTypeIds);
+
+	Task<List<UnitOfMeasure>> GetAllUnitsOfMeasure();
+	Task<UnitOfMeasure> CreateUnitOfMeasure(UnitOfMeasure unitOfMeasure);
+	Task<UnitOfMeasure> UpdateUnitOfMeasure(UnitOfMeasure unitOfMeasure);
+	Task<int> DeleteUnitsOfMeasure(HashSet<long> unitOfMeasureIds);
 }

--- a/ApplicationCore/Services/Prices/PriceDbAccess.cs
+++ b/ApplicationCore/Services/Prices/PriceDbAccess.cs
@@ -74,4 +74,34 @@ public class PriceDbAccess : IPriceDbAccess
 			.Where(priceType => priceTypeIds.Contains(priceType.Id))
 			.ExecuteDeleteAsync();
 	}
+
+	public async Task<List<UnitOfMeasure>> GetAllUnitsOfMeasure()
+	{
+		var context = await _dbContextFactory.CreateDbContextAsync();
+		return await context.UnitsOfMeasure.OrderBy(unitOfMeasure => unitOfMeasure.Name).ToListAsync();
+	}
+
+	public async Task<UnitOfMeasure> CreateUnitOfMeasure(UnitOfMeasure unitOfMeasure)
+	{
+		await using var context = await _dbContextFactory.CreateDbContextAsync();
+		context.UnitsOfMeasure.Add(unitOfMeasure);
+		await context.SaveChangesAsync();
+		return unitOfMeasure;
+	}
+
+	public async Task<UnitOfMeasure> UpdateUnitOfMeasure(UnitOfMeasure unitOfMeasure)
+	{
+		await using var context = await _dbContextFactory.CreateDbContextAsync();
+		context.UnitsOfMeasure.Update(unitOfMeasure);
+		await context.SaveChangesAsync();
+		return unitOfMeasure;
+	}
+
+	public async Task<int> DeleteUnitsOfMeasure(HashSet<long> unitOfMeasureIds)
+	{
+		await using var context = await _dbContextFactory.CreateDbContextAsync();
+		return await context.UnitsOfMeasure
+			.Where(unitOfMeasure => unitOfMeasureIds.Contains(unitOfMeasure.Id))
+			.ExecuteDeleteAsync();
+	}
 }

--- a/ApplicationCore/Services/Prices/PriceService.cs
+++ b/ApplicationCore/Services/Prices/PriceService.cs
@@ -23,11 +23,27 @@ public class PriceService : IPriceService
 	public Task<int> DeletePrices(HashSet<long> priceIds) 
 		=> _priceDbAccess.DeletePrices(priceIds);
 
-	public Task<List<PriceType>> GetAllPriceTypes() => _priceDbAccess.GetAllPriceTypes();
+	public Task<List<PriceType>> GetAllPriceTypes()
+		=> _priceDbAccess.GetAllPriceTypes();
 
-	public Task<PriceType> CreatePriceType(PriceType priceType) => _priceDbAccess.CreatePriceType(priceType);
+	public Task<PriceType> CreatePriceType(PriceType priceType)
+		=> _priceDbAccess.CreatePriceType(priceType);
 
-	public Task<PriceType> UpdatePriceType(PriceType priceType) => _priceDbAccess.UpdatePriceType(priceType);
+	public Task<PriceType> UpdatePriceType(PriceType priceType)
+		=> _priceDbAccess.UpdatePriceType(priceType);
 
-	public Task<int> DeletePriceTypes(HashSet<long> priceTypeIds) => _priceDbAccess.DeletePriceTypes(priceTypeIds);
+	public Task<int> DeletePriceTypes(HashSet<long> priceTypeIds)
+		=> _priceDbAccess.DeletePriceTypes(priceTypeIds);
+
+	public Task<List<UnitOfMeasure>> GetAllUnitsOfMeasure()
+		=> _priceDbAccess.GetAllUnitsOfMeasure();
+
+	public Task<UnitOfMeasure> CreateUnitOfMeasure(UnitOfMeasure unitOfMeasure)
+		=> _priceDbAccess.CreateUnitOfMeasure(unitOfMeasure);
+
+	public Task<UnitOfMeasure> UpdateUnitOfMeasure(UnitOfMeasure unitOfMeasure)
+		=> _priceDbAccess.UpdateUnitOfMeasure(unitOfMeasure);
+
+	public Task<int> DeleteUnitsOfMeasure(HashSet<long> unitOfMeasureIds)
+		=> _priceDbAccess.DeleteUnitsOfMeasure(unitOfMeasureIds);
 }

--- a/DotNetCodeTest.sln
+++ b/DotNetCodeTest.sln
@@ -3,11 +3,11 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33417.168
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UI", "UI\UI.csproj", "{81F6CCD5-8795-472E-8352-9573581F8A44}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UI", "UI\UI.csproj", "{81F6CCD5-8795-472E-8352-9573581F8A44}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApplicationCore", "ApplicationCore\ApplicationCore.csproj", "{C485E419-2FA8-4B10-AF43-FF7069B79C07}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ApplicationCore", "ApplicationCore\ApplicationCore.csproj", "{C485E419-2FA8-4B10-AF43-FF7069B79C07}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests", "Tests\Tests.csproj", "{D877AB81-DBCB-410A-B17A-A7E7432C3096}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tests", "Tests\Tests.csproj", "{D877AB81-DBCB-410A-B17A-A7E7432C3096}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -10,6 +10,10 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.10.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.4">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageReference Include="Moq" Version="4.18.4" />
         <PackageReference Include="xunit" Version="2.4.2" />

--- a/UI/Pages/PriceDialog.razor
+++ b/UI/Pages/PriceDialog.razor
@@ -2,16 +2,26 @@
 @using ApplicationCore.Services
 @using FluentValidation
 @inject IPriceService PriceService
+@inject IProductService ProductService
 @inject IValidator<Price> Validator
 
 <MudDialog>
 	<DialogContent>
 		<MudForm @ref="_form" Model="Price" Validation="Validator.FormValidate()">
-			<MudNumericField Label="Product ID" Required="true"
-			                 @bind-Value="Price.ProductId" For="@(() => Price.ProductId)"/>
+			@*<MudNumericField Label="Product ID" Required="true"
+			                 @bind-Value="Price.ProductId" For="@(() => Price.ProductId)"/>*@
+			<MudSelect Label="Product" Required="true" @bind-Value="Price.ProductId" For="@(() => Price.ProductId)">
+				@if (products != null)
+				{
+					foreach (var product in products)
+					{
+						<MudSelectItem TValue="string" Value="@product.Id">@($"{product.Id}: {product.ProductNumber} - {product.Name}")</MudSelectItem>
+					}
+				}
+			</MudSelect>
 			<MudTextField Label="Price type" Required="true"
 			              @bind-Value="Price.PriceTypeName" For="@(() => Price.PriceTypeName)"/>
-			<MudNumericField Label="Amount" bind-Value="Price.Amount" For="@(() => Price.Amount)"/>
+			<MudNumericField Label="Amount" @bind-Value="Price.Amount" For="@(() => Price.Amount)"/>
 			<MudTextField Label="Unit of measure"
 			              @bind-Value="Price.UnitOfMeasureName" For="@(() => Price.UnitOfMeasureName)"/>
 			<MudNumericField Label="Quantity from" @bind-Value="Price.QuantityFrom" For="@(() => Price.QuantityFrom)"/>
@@ -34,6 +44,13 @@
 	public Price Price { get; set; } = new() { ProductId = default, PriceTypeName = string.Empty, UnitOfMeasureName = string.Empty};
 
 	MudForm _form = new();
+
+	private List<Product> products;
+
+	protected override async Task OnInitializedAsync()
+	{
+		products = await ProductService.GetAllProductsAsync();
+	}
 
 	private DateTime? FromDateTime
 	{

--- a/UI/Pages/PriceDialog.razor
+++ b/UI/Pages/PriceDialog.razor
@@ -8,8 +8,6 @@
 <MudDialog>
 	<DialogContent>
 		<MudForm @ref="_form" Model="Price" Validation="Validator.FormValidate()">
-			@*<MudNumericField Label="Product ID" Required="true"
-			                 @bind-Value="Price.ProductId" For="@(() => Price.ProductId)"/>*@
 			<MudSelect Label="Product" Required="true" @bind-Value="Price.ProductId" For="@(() => Price.ProductId)">
 				@if (products != null)
 				{

--- a/UI/Pages/PriceTypes.razor
+++ b/UI/Pages/PriceTypes.razor
@@ -50,7 +50,7 @@
 
 	async Task NewClicked()
 	{
-		var dialog = await DialogService.ShowAsync<PriceTypeDialog>("Create rpice type");
+		var dialog = await DialogService.ShowAsync<PriceTypeDialog>("Create Price Type");
 		var result = await dialog.Result;
 
 		if (result.Data is PriceType createdPriceType)

--- a/UI/Pages/UnitOfMeasureDialog.razor
+++ b/UI/Pages/UnitOfMeasureDialog.razor
@@ -1,0 +1,55 @@
+﻿@using ApplicationCore.DataModel
+@using ApplicationCore.Services
+@using FluentValidation
+@inject IValidator<UnitOfMeasure> Validator
+@inject IPriceService PriceService
+
+<MudDialog>
+	<DialogContent>
+		<MudForm @ref="_form" Model="UnitOfMeasure" Validation="Validator.FormValidate()">
+			<MudTextField Label="Name" Required="true"
+						  @bind-Value="UnitOfMeasure.Name" For="@(() => UnitOfMeasure.Name)" />
+			<MudTextField Label="Description"
+						  @bind-Value="UnitOfMeasure.Description" For="@(() => UnitOfMeasure.Description)" />
+			<MudTextField Label="External ID"
+						  @bind-Value="UnitOfMeasure.ExternalId" For="@(() => UnitOfMeasure.ExternalId)" />
+		</MudForm>
+	</DialogContent>
+	<DialogActions>
+		<MudButton OnClick="CancelClicked">Cancel</MudButton>
+		<MudButton ButtonType="ButtonType.Submit" OnClick="SaveClicked">Save</MudButton>
+	</DialogActions>
+</MudDialog>
+
+@code {
+
+	[CascadingParameter]
+	public required MudDialogInstance Dialog { get; set; }
+
+	[Parameter]
+	public UnitOfMeasure UnitOfMeasure { get; set; } = new() { Name = string.Empty };
+
+	MudForm _form = new();
+
+	void CancelClicked() => Dialog.Close();
+
+	async Task SaveClicked()
+	{
+		await _form.Validate();
+
+		if (_form.IsValid)
+		{
+			if (UnitOfMeasure.Id != default)
+			{
+				UnitOfMeasure = await PriceService.UpdateUnitOfMeasure(UnitOfMeasure);
+			}
+			else
+			{
+				UnitOfMeasure = await PriceService.CreateUnitOfMeasure(UnitOfMeasure);
+			}
+
+			Dialog.Close(UnitOfMeasure);
+		}
+	}
+
+}

--- a/UI/Pages/UnitsOfMeasure.razor
+++ b/UI/Pages/UnitsOfMeasure.razor
@@ -1,0 +1,78 @@
+﻿@page "/Setup/UnitsOfMeasure"
+@using ApplicationCore.DataModel
+@using ApplicationCore.Services
+@inject IPriceService PriceService
+@inject IDialogService DialogService
+
+<PageTitle>Units of Measure</PageTitle>
+<MudDataGrid Items="_unitsOfMeasure" @ref="_grid" ShowMenuIcon="true" MultiSelection="true"
+			 Filterable="true" FilterMode="DataGridFilterMode.ColumnFilterMenu" FilterCaseSensitivity="DataGridFilterCaseSensitivity.CaseInsensitive"
+			 Striped="true" Bordered="true" Hideable="true" ColumnResizeMode="ResizeMode.Column" FixedHeader="true">
+	<ToolBarContent>
+		<MudText Typo="Typo.h5">Units of Measure</MudText>
+		<MudSpacer />
+		<MudButton Variant="Variant.Text" Color="Color.Success" StartIcon="@Icons.Material.Filled.Add" Class="mx-1" OnClick="NewClicked">New</MudButton>
+		<MudButton Variant="Variant.Text" Color="Color.Error" StartIcon="@Icons.Material.Filled.Delete" Class="mx-1" OnClick="DeleteClicked">Delete</MudButton>
+		<MudIconButton Variant="Variant.Text" Color="Color.Info" Icon="@Icons.Material.Filled.Refresh" OnClick="RefreshGrid" />
+	</ToolBarContent>
+	<Columns>
+		<SelectColumn T="UnitOfMeasure" ShowInFooter="false" />
+		<Column T="UnitOfMeasure" Title="Name">
+			<CellTemplate>
+				<MudLink Href="@($"/Products/{context.Item.Name}")">@context.Item.Name</MudLink>
+			</CellTemplate>
+		</Column>
+		<Column T="UnitOfMeasure" Field="Description" Title="Description" />
+		<Column T="UnitOfMeasure" Field="ExternalId" Title="External ID" />
+		<Column T="UnitOfMeasure" Title="Edit" Filterable="false" Sortable="false" Hideable="false">
+			<CellTemplate>
+				<MudIconButton Size="Size.Small" Icon="@Icons.Material.Filled.Edit" OnClick="@(() => EditClicked(context.Item))" />
+			</CellTemplate>
+		</Column>
+	</Columns>
+</MudDataGrid>
+
+@code {
+	List<UnitOfMeasure> _unitsOfMeasure = new();
+	MudDataGrid<UnitOfMeasure> _grid = new();
+
+	protected override async Task OnInitializedAsync()
+	{
+		await base.OnInitializedAsync();
+
+		_unitsOfMeasure = await PriceService.GetAllUnitsOfMeasure();
+	}
+
+	async Task RefreshGrid()
+	{
+
+	}
+
+	async Task NewClicked()
+	{
+		var dialog = await DialogService.ShowAsync<UnitOfMeasureDialog>("Create Unit of Measure");
+		var result = await dialog.Result;
+
+		if (result.Data is UnitOfMeasure createdUnitOfMeasure)
+		{
+			_unitsOfMeasure.Add(createdUnitOfMeasure);
+			_unitsOfMeasure = _unitsOfMeasure.OrderBy(unitOfMeasure => unitOfMeasure.Name).ToList();
+		}
+	}
+
+	async Task EditClicked(UnitOfMeasure unitOfMeasure)
+	{
+		var dialog = await DialogService.ShowAsync<UnitOfMeasureDialog>("Update Unit of Measure",
+			new DialogParameters
+				{
+				{ "UnitOfMeasure", unitOfMeasure }
+				});
+		await dialog.Result;
+	}
+
+	async Task DeleteClicked()
+	{
+		await PriceService.DeleteUnitsOfMeasure(_grid.SelectedItems.Select(unitOfMeasure => unitOfMeasure.Id).ToHashSet());
+		_unitsOfMeasure.RemoveAll(unitOfMeasure => _grid.SelectedItems.Contains(unitOfMeasure));
+	}
+}

--- a/UI/Program.cs
+++ b/UI/Program.cs
@@ -13,7 +13,7 @@ builder.Services.AddMudServices();
 
 builder.Services.AddPooledDbContextFactory<StraboContext>(options =>
 {
-	options.UseNpgsql("Host=localhost;Database=strabocodetest;Username=strabo;Password=strabo")
+	options.UseNpgsql("Host=localhost;Database=strabocodetest;Username=postgres;Password=admin")
 		.EnableDetailedErrors()
 		.EnableSensitiveDataLogging();
 });

--- a/UI/Shared/NavMenu.razor
+++ b/UI/Shared/NavMenu.razor
@@ -1,8 +1,9 @@
 ﻿<MudNavMenu>
     <MudNavLink Href="" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Home">Home</MudNavLink>
-    <MudNavLink Href="/Products">Products</MudNavLink>
+    <MudNavLink Href="/Products" Icon="@Icons.Material.Filled.Apps">Products</MudNavLink>
     <MudNavLink Href="/Prices" Icon="@Icons.Material.Filled.Money">Prices</MudNavLink>
     <MudNavGroup Title="Setup" Icon="@Icons.Material.Filled.Settings">
-        <MudNavLink Href="/Setup/PriceTypes" Icon="@Icons.Material.Filled.MergeType">Price types</MudNavLink>
+        <MudNavLink Href="/Setup/PriceTypes" Icon="@Icons.Material.Filled.MergeType">Price Types</MudNavLink>
+        <MudNavLink Href="/Setup/UnitsOfMeasure" Icon="@Icons.Material.Filled.FormatSize">Units of Measure</MudNavLink>
     </MudNavGroup>
 </MudNavMenu>

--- a/UI/UI.csproj
+++ b/UI/UI.csproj
@@ -14,6 +14,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="MudBlazor" Version="6.1.9" />
   </ItemGroup>
 


### PR DESCRIPTION
UI - PriceDialog.razor
1. Replaced MudNumericField for populating ProductId with a MudSelect Field to populate a list of available products with their respective Product Id, Product number, and Product name.
2. When testing the altered dialog, I noticed that the price was not populating in the created price object. Discovered and fixed the issue, which was related to a missing @ symbol for the bind-value for the Price.Amount property.